### PR TITLE
Enhance service launch and UI improvements

### DIFF
--- a/FalconsFactionMonitor/FalconsFactionMonitor/MainWindow.xaml.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/MainWindow.xaml.cs
@@ -1,5 +1,5 @@
-﻿using FalconsFactionMonitor.Services;
-using System;
+﻿using System;
+using System.Threading;
 using System.Windows;
 
 namespace FalconsFactionMonitor.Windows
@@ -17,6 +17,7 @@ namespace FalconsFactionMonitor.Windows
             ResultTextBlock.Document.Blocks.Clear();
             ResultTextBlock.Foreground = System.Windows.Media.Brushes.Fuchsia;
             ResultTextBlock.AppendText("Starting Journal Monitor Service.");
+            Thread.Sleep(1000);
             Hide();
             JournalMonitorWindow journalMonitorWindow = new JournalMonitorWindow();
             journalMonitorWindow.Show();
@@ -25,13 +26,11 @@ namespace FalconsFactionMonitor.Windows
         private void WebRetrievalServiceButton_Click(object sender, RoutedEventArgs e)
         {
             ResultTextBlock.Document.Blocks.Clear();
-            ResultTextBlock.Foreground = System.Windows.Media.Brushes.Red;
-            ResultTextBlock.AppendText("Web Retrieval Service is not yet implemented.");
-            //ResultTextBlock.Document.Blocks.Clear();
-            //ResultTextBlock.AppendText("StartingWeb Retrieval Service.");
-            //Hide();
-            //WebRetrievalWindow webRetrievalWindow = new WebRetrievalWindow();
-            //webRetrievalWindow.Show();
+            ResultTextBlock.AppendText("Starting Web Retrieval Service.");
+            Thread.Sleep(1000);
+            Hide();
+            WebRetrievalWindow webRetrievalWindow = new WebRetrievalWindow();
+            webRetrievalWindow.Show();
         }
 
         private void ExitButton_Click(object sender, RoutedEventArgs e)

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Services/WebRetrieval.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Services/WebRetrieval.cs
@@ -44,7 +44,7 @@ namespace FalconsFactionMonitor.Services
                     systems = await GetData.GetFactionSystems(factionName);
                     SaveToCSV.FactionSystems(systems, filePath);
                     Console.ForegroundColor = ConsoleColor.Cyan;
-                    Console.Write("\n[INFO]");
+                    Console.Write("\n[INFO] ");
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.WriteLine($"The systems {factionName} can be found in has been saved to '{filePath}'.");
                 }
@@ -91,7 +91,7 @@ namespace FalconsFactionMonitor.Services
 
                 SaveToCSV.SystemFactions(allFactions, factionsFilePath);
                 Console.ForegroundColor = ConsoleColor.Cyan;
-                Console.Write("\n[INFO]");
+                Console.Write("\n[INFO] ");
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.WriteLine($"The full faction list for systems {factionName} can be found in has been saved to '{factionsFilePath}'.");
 
@@ -99,7 +99,7 @@ namespace FalconsFactionMonitor.Services
             catch (Exception ex)
             {
                 Console.ForegroundColor = ConsoleColor.DarkRed;
-                Console.Write("\n[ERROR]");
+                Console.Write("\n[ERROR] ");
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.WriteLine($" {ex.Message}");
             }

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Windows/JournalMonitorWindow.xaml.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Windows/JournalMonitorWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using FalconsFactionMonitor.Services;
-using FalconsFactionMonitor.Windows;
 using System;
 using System.Windows;
 
@@ -13,11 +12,11 @@ namespace FalconsFactionMonitor.Windows
             Console.SetOut(new RichTextBoxWriter(JournalOutputTextBlock));
         }
 
-        private void StartJMServiceButton_Click(object sender, RoutedEventArgs e)
+        private async void StartJMServiceButton_Click(object sender, RoutedEventArgs e)
         {
             JournalOutputTextBlock.Document.Blocks.Clear();
             JournalRetrievalService service = new JournalRetrievalService();
-            service.JournalRetrieval().Wait();
+            await service.JournalRetrieval();
         }
 
         private void ExitJMServiceButton_Click(object sender, RoutedEventArgs e)

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Windows/WebRetrievalWindow.xaml
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Windows/WebRetrievalWindow.xaml
@@ -19,6 +19,9 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
         <StackPanel Grid.Row="0">
             <Viewbox Stretch="Uniform"
                      StretchDirection="Both"
@@ -92,15 +95,31 @@
                      HorizontalScrollBarVisibility="Auto"
                      Grid.Row="1"
                      IsReadOnly="True"/>
-        <Button x:Name="ExitJMServiceButton"
-                Content="Exit Monitor Service"
-                HorizontalAlignment="Center"
-                Background="Black"
-                Foreground="White"
-                Width="200"
-                Height="30"
-                Margin="0,10,0,0"
-                Grid.Row="2"
-                Click="ExitJMServiceButton_Click" />
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="OpenOutputButton"
+                    Content="Open Output Directory"
+                    HorizontalAlignment="Center"
+                    Background="Black"
+                    Foreground="White"
+                    Width="200"
+                    Height="30"
+                    Margin="60,5,0,5"
+                    Grid.Column="0"
+                    Click="OpenOutputButton_Click" />
+            <Button x:Name="ExitWRServiceButton"
+                    Content="Exit Monitor Service"
+                    HorizontalAlignment="Right"
+                    Background="Black"
+                    Foreground="White"
+                    Width="200"
+                    Height="30"
+                    Margin="0,5,60,5"
+                    Grid.Column="1"
+                    Click="ExitWRServiceButton_Click" />
+        </Grid>
     </Grid>
 </Window>

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Windows/WebRetrievalWindow.xaml.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Windows/WebRetrievalWindow.xaml.cs
@@ -1,7 +1,8 @@
 ﻿using FalconsFactionMonitor.Services;
 using System;
 using System.Windows;
-using FalconsFactionMonitor.Windows;
+using System.Diagnostics;
+using System.IO;
 
 namespace FalconsFactionMonitor.Windows
 {
@@ -16,7 +17,7 @@ namespace FalconsFactionMonitor.Windows
             Console.SetOut(new RichTextBoxWriter(WebRetrievalOutputTextBlock));
         }
 
-        private void StartWRServiceButton_Click(object sender, RoutedEventArgs e)
+        private async void StartWRServiceButton_Click(object sender, RoutedEventArgs e)
         {
             bool check = false;
             if (InaraCheckBox.IsChecked == true)
@@ -25,15 +26,22 @@ namespace FalconsFactionMonitor.Windows
             }
             WebRetrievalOutputTextBlock.Document.Blocks.Clear();
             WebRetrievalOutputTextBlock.Foreground = System.Windows.Media.Brushes.White;
+            WebRetrievalOutputTextBlock.AppendText("Program starting execution. This may take a few minutes to run");
             WebRetrievalService service = new WebRetrievalService();
-            service.WebRetrieval(FactionTextBox.Text, inaraParse: check).Wait();
+            await service.WebRetrieval(FactionTextBox.Text, inaraParse: check);
         }
 
-        private void ExitJMServiceButton_Click(object sender, RoutedEventArgs e)
+        private void ExitWRServiceButton_Click(object sender, RoutedEventArgs e)
         {
             MainWindow mainWindow = new MainWindow();
             mainWindow.Show();
             Close();
+        }
+
+        private void OpenOutputButton_Click(object sender, RoutedEventArgs e)
+        {
+            var OutputPath = Path.Combine(Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory)?.FullName, "Output");
+            Process.Start("explorer.exe", OutputPath);
         }
     }
 }


### PR DESCRIPTION
- Added a 1-second delay before launching Journal Monitor and Web Retrieval services in MainWindow.
- Updated console output formatting in WebRetrieval.cs for better readability.
- Made StartJMServiceButton_Click asynchronous in JournalMonitorWindow.xaml.cs to ensure database calls work.
- Redesigned WebRetrievalWindow.xaml layout to include new button for opening the output directory alongside the button for exiting the service.
- Made StartWRServiceButton_Click asynchronous in WebRetrievalWindow.xaml.cs to fix http calls, and added functionality to open the output directory.

#7