### PR TITLE
100% Influence Fix

### DIFF
--- a/FalconsFactionMonitor/FalconsFactionMonitor/FalconsFactionMonitor.csproj
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/FalconsFactionMonitor.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
-    <AssemblyVersion>4.1.4.0</AssemblyVersion>
-    <FileVersion>4.1.4.0</FileVersion>
-    <InformationalVersion>4.1.4 (Report Implementation)</InformationalVersion>
+    <AssemblyVersion>4.1.5.0</AssemblyVersion>
+    <FileVersion>4.1.5.0</FileVersion>
+    <InformationalVersion>4.1.5 (100 Percent Influence Fix)</InformationalVersion>
 	<EnableWindowsTargeting>true</EnableWindowsTargeting>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Models/EDSMData.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Models/EDSMData.cs
@@ -49,7 +49,7 @@ namespace FalconsFactionMonitor.Models
         public string name { get; set; }
         public string allegiance { get; set; }
         public string government { get; set; }
-        public double influence { get; set; }
+        public decimal influence { get; set; }
         public string state { get; set; }
         public List<State> activeStates { get; set; }
         public List<State> recoveringStates { get; set; }

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Models/FactionDetail.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Models/FactionDetail.cs
@@ -4,8 +4,8 @@
     {
         public string SystemName { get; set; }
         public string FactionName { get; set; }
-        public double InfluencePercent { get; set; }
-        public double Difference { get; set; }
+        public decimal InfluencePercent { get; set; }
+        public decimal Difference { get; set; }
         public bool IsPlayer { get; set; }
         public string LastUpdated { get; set; }
     }

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Models/FactionSystem.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Models/FactionSystem.cs
@@ -4,6 +4,6 @@
     {
         public string SystemName { get; set; }
         public string LastUpdated { get; set; }
-        public double InfluencePercent { get; set; }
+        public decimal InfluencePercent { get; set; }
     }
 }

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Models/LiveData.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Models/LiveData.cs
@@ -4,7 +4,7 @@
     {
         public string SystemName { get; set; }
         public string FactionName { get; set; }
-        public double InfluencePercent { get; set; }
+        public decimal InfluencePercent { get; set; }
         public string State { get; set; }
         public bool IsPlayer { get; set; }
         public bool NativeFaction { get; set; }

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Services/DatabaseService.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Services/DatabaseService.cs
@@ -3,6 +3,7 @@ using FalconsFactionMonitor.Models;
 using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -63,12 +64,20 @@ namespace FalconsFactionMonitor.Services
 
                     using SqlCommand command = new(storedProc, connection);
                     {
-                        command.Parameters.AddWithValue("@SystemName", faction.SystemName);
-                        command.Parameters.AddWithValue("@FactionName", faction.FactionName);
-                        command.Parameters.AddWithValue("@Influence", faction.InfluencePercent);
-                        command.Parameters.AddWithValue("@State", faction.State);
-                        command.Parameters.AddWithValue("@PlayerFaction", faction.IsPlayer);
-                        command.Parameters.AddWithValue("@LastUpdated", faction.LastUpdated);
+                        var p = new SqlParameter("@Influence", SqlDbType.Decimal)
+                        {
+                            Precision = 5,
+                            Scale = 2
+                        };
+                        p.Value = faction.InfluencePercent;
+                        command.Parameters.Add(p);
+
+                        command.Parameters.Add("@SystemName", SqlDbType.NVarChar, 255).Value = faction.SystemName;
+                        command.Parameters.Add("@FactionName", SqlDbType.NVarChar, 255).Value = faction.FactionName;
+                        command.Parameters.Add("@State", SqlDbType.NVarChar, 50).Value = faction.State;
+                        command.Parameters.Add("@PlayerFaction", SqlDbType.Bit).Value = faction.IsPlayer;
+                        command.Parameters.Add("@LastUpdated", SqlDbType.DateTimeOffset).Value =
+                            DateTime.ParseExact(faction.LastUpdated, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
                         command.ExecuteNonQuery();
                     }
                 }

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Services/GetData.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Services/GetData.cs
@@ -51,7 +51,7 @@ internal static class GetData
             var influenceText = cells[1].InnerText.Trim();
             var lastUpdatedText = cells[3].InnerText.Trim();
 
-            if (double.TryParse(influenceText.TrimEnd('%'), out double influence))
+            if (decimal.TryParse(influenceText.TrimEnd('%'), out decimal influence))
             {
                 systems.Add(new FactionSystem
                 {
@@ -89,7 +89,7 @@ internal static class GetData
 
                 foreach (var faction in responseJSON.factions)
                 {
-                    var influence = Math.Round(faction.influence * 100, 2);
+                    decimal influence = Math.Round(faction.influence * 100m, 2);
                     string lastUpdated = DateTimeOffset.FromUnixTimeSeconds(faction.lastUpdate).UtcDateTime.ToString();
 
                     allFactions.Add(new FactionDetail
@@ -180,8 +180,8 @@ internal static class GetData
             var columns = line.Split(',');
             if (columns.Length < 5) continue;
 
-            if (double.TryParse(columns[2], NumberStyles.Any, CultureInfo.InvariantCulture, out double influencePercent) &&
-                double.TryParse(columns[3], NumberStyles.Any, CultureInfo.InvariantCulture, out double difference))
+            if (decimal.TryParse(columns[2], NumberStyles.Any, CultureInfo.InvariantCulture, out decimal influencePercent) &&
+                decimal.TryParse(columns[3], NumberStyles.Any, CultureInfo.InvariantCulture, out decimal difference))
             {
                 factions.Add(new FactionDetail
                 {
@@ -214,7 +214,7 @@ internal static class GetData
             var columns = line.Split(',');
             if (columns.Length < 3) continue;
 
-            if (double.TryParse(columns[1], NumberStyles.Any, CultureInfo.InvariantCulture, out double influencePercent))
+            if (decimal.TryParse(columns[1], NumberStyles.Any, CultureInfo.InvariantCulture, out decimal influencePercent))
             {
                 systems.Add(new FactionSystem
                 {
@@ -263,7 +263,7 @@ internal static class GetData
                     var values = reader.ReadLine()?.Split(',');
                     if (values == null || values.Length < 3) continue;
 
-                    if (double.TryParse(values[influenceIndex], NumberStyles.Any, CultureInfo.InvariantCulture, out double influence))
+                    if (decimal.TryParse(values[influenceIndex], NumberStyles.Any, CultureInfo.InvariantCulture, out decimal influence))
                     {
                         list.Add(new FactionSystem
                         {

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Services/JournalMonitor.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Services/JournalMonitor.cs
@@ -269,8 +269,8 @@ namespace FalconsFactionMonitor.Services
                             {
                                 foreach (var faction in factions)
                                 {
-                                    double influence = faction["Influence"]?.ToObject<double>() ?? 0.0;
-                                    influence = Math.Round(influence * 100, 2);  // Convert from 0.x to xx.xx
+                                    decimal influence = faction["Influence"]?.ToObject<decimal>() ?? 0.0m;
+                                    influence = Math.Round(influence * 100m, 2);  // Convert from 0.x to xx.xx
 
                                     bool isPlayer = faction["SquadronFaction"]?.ToObject<bool>() ?? false;
                                     string state = faction["FactionState"]?.ToString();

--- a/FalconsFactionMonitor/Setup/Setup.aip
+++ b/FalconsFactionMonitor/Setup/Setup.aip
@@ -34,10 +34,10 @@
     <ROW Property="ARPURLINFOABOUT" Value="https://github.com/Falcon-Charade/FalconsFactionMonitor"/>
     <ROW Property="ARPURLUPDATEINFO" Value="https://github.com/Falcon-Charade/FalconsFactionMonitor/releases/latest"/>
     <ROW Property="Manufacturer" Value="FalconCharade"/>
-    <ROW Property="ProductCode" Value="1033:{20E95C17-6976-49AB-B526-6F0EA46CB505} " Type="16"/>
+    <ROW Property="ProductCode" Value="1033:{FC8D082F-A6B7-4B61-B6E7-2977E4075661} " Type="16"/>
     <ROW Property="ProductLanguage" Value="1033"/>
     <ROW Property="ProductName" Value="FalconsFactionMonitor"/>
-    <ROW Property="ProductVersion" Value="4.1.4" Options="32"/>
+    <ROW Property="ProductVersion" Value="4.1.5" Options="32"/>
     <ROW Property="SecureCustomProperties" Value="OLDPRODUCTS;AI_NEWERPRODUCTFOUND"/>
     <ROW Property="UpgradeCode" Value="{0BB77E5D-777D-4A66-BF04-D87EB58DE111}"/>
     <ROW Property="WindowsType9X" MultiBuildValue="DefaultBuild:Windows 9x/ME" ValueLocId="-"/>


### PR DESCRIPTION
# 🚀 Pull Request: 100% Influence Fix

## 📌 Purpose
This pull request fixes the issue when a faction had 100% influence in a system
Upload to database no longer fails when a faction has 100% influence

---

## ✅ Key Features
- 100% Influence Fix

---

## 🧠 Commit Highlights
- [`9707acd`](https://github.com/Falcon-Charade/FalconsFactionMonitor/commit/9707acd02e63afb5838802be05e63a74b86c248c) – 100% Influence Fix
  - Updated project file to version 4.1.5 with a fix for "100 Percent Influence".
  - Changed influence properties from double to decimal in multiple files to prevent errors when a faction has 100% influence.
  - Modified database parameter handling to accommodate decimal types.
  - Adjusted parsing methods to ensure consistency across the application.
  - Updated installer configuration to reflect the new version.

---

## 🗂️ Modified Files

<details><summary>Added</summary>
<p>

_None_

</p>
</details>

<details><summary>Modified</summary>
<p>

- Models:
  - `EDSMData.cs`
  - `FactionDetail.cs`
  - `FactionSystem.cs`
  - `LiveData.cs`
- Services:
  - `DatabaseService.cs`
  - `GetData.cs`
  - `JournalMonitor.cs`

</p>
</details>

<details><summary>Removed</summary>
<p>

_None_

</p>
</details>

---

## ⚠ Known Issues / Notes
- No new issues introduced
