### PR TITLE
WebRetrival Fix for Influence List

### DIFF
--- a/FalconsFactionMonitor/FalconsFactionMonitor/FalconsFactionMonitor.csproj
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/FalconsFactionMonitor.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
-    <AssemblyVersion>4.1.5.0</AssemblyVersion>
-    <FileVersion>4.1.5.0</FileVersion>
-    <InformationalVersion>4.1.5 (100 Percent Influence Fix)</InformationalVersion>
+    <AssemblyVersion>4.1.6.0</AssemblyVersion>
+    <FileVersion>4.1.6.0</FileVersion>
+    <InformationalVersion>4.1.6 (WebRetrival Fix for Influence List)</InformationalVersion>
 	<EnableWindowsTargeting>true</EnableWindowsTargeting>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/FalconsFactionMonitor/FalconsFactionMonitor/Services/GetData.cs
+++ b/FalconsFactionMonitor/FalconsFactionMonitor/Services/GetData.cs
@@ -15,7 +15,7 @@ internal static class GetData
     {
         using var client = new HttpClient();
 
-        string url = $"https://inara.cz/elite/minorfaction/?search={Uri.EscapeDataString(factionName)}";
+        string url = $"https://inara.cz/elite/minorfaction-presence/?search={Uri.EscapeDataString(factionName)}";
 
         var response = await client.GetAsync(url);
 
@@ -48,8 +48,9 @@ internal static class GetData
             if (cells == null || cells.Count < 4) continue;
 
             var systemName = cells[0].InnerText.Trim();
-            var influenceText = cells[1].InnerText.Trim();
-            var lastUpdatedText = cells[3].InnerText.Trim();
+            systemName = systemName.Substring(0, systemName.Length - 2);
+            var influenceText = cells[7].InnerText.Trim();
+            var lastUpdatedText = cells[8].InnerText.Trim();
 
             if (decimal.TryParse(influenceText.TrimEnd('%'), out decimal influence))
             {

--- a/FalconsFactionMonitor/Setup/Setup.aip
+++ b/FalconsFactionMonitor/Setup/Setup.aip
@@ -34,10 +34,10 @@
     <ROW Property="ARPURLINFOABOUT" Value="https://github.com/Falcon-Charade/FalconsFactionMonitor"/>
     <ROW Property="ARPURLUPDATEINFO" Value="https://github.com/Falcon-Charade/FalconsFactionMonitor/releases/latest"/>
     <ROW Property="Manufacturer" Value="FalconCharade"/>
-    <ROW Property="ProductCode" Value="1033:{FC8D082F-A6B7-4B61-B6E7-2977E4075661} " Type="16"/>
+    <ROW Property="ProductCode" Value="1033:{3623F9FE-D048-4481-B13B-7D3BB2368261} " Type="16"/>
     <ROW Property="ProductLanguage" Value="1033"/>
     <ROW Property="ProductName" Value="FalconsFactionMonitor"/>
-    <ROW Property="ProductVersion" Value="4.1.5" Options="32"/>
+    <ROW Property="ProductVersion" Value="4.1.6" Options="32"/>
     <ROW Property="SecureCustomProperties" Value="OLDPRODUCTS;AI_NEWERPRODUCTFOUND"/>
     <ROW Property="UpgradeCode" Value="{0BB77E5D-777D-4A66-BF04-D87EB58DE111}"/>
     <ROW Property="WindowsType9X" MultiBuildValue="DefaultBuild:Windows 9x/ME" ValueLocId="-"/>


### PR DESCRIPTION
# 🚀 Pull Request: WebRetrival Fix for Influence List

## 📌 Purpose
This pull request fixes the issue where not all systems for a faction were being returned.
When doing an Inara search with the WebRetrieval service, it will now pull back all systems from the "Star Systems" tab, not the "Overview" tab

---

## ✅ Key Features
- WebRetrival Fix

---

## 🧠 Commit Highlights
- [`66fa280`](https://github.com/Falcon-Charade/FalconsFactionMonitor/commit/66fa280ba98cf1b3654655be9f7b58a5b42c9725) – WebRetrival Fix for Influence List
  - Changed data fetching URL from `minorfaction` to `minorfaction-presence` for improved accuracy.
  - Adjusted parsing logic in `GetData.cs` to align with new data structure.
  - Updated `FalconsFactionMonitor.csproj` to version 4.1.6.0 with fixes for web retrieval.
  - Updated product code and version in `Setup.aip` to reflect the new release.

---

## 🗂️ Modified Files

<details><summary>Added</summary>
<p>

_None_

</p>
</details>

<details><summary>Modified</summary>
<p>

- Services:
  - `GetData.cs`

</p>
</details>

<details><summary>Removed</summary>
<p>

_None_

</p>
</details>

---

## ⚠ Known Issues / Notes
- No new issues introduced
